### PR TITLE
Handling of repeated parameters when generating object creation statements for parameters

### DIFF
--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/RepeatedValueTypeParameters.txt
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/RepeatedValueTypeParameters.txt
@@ -1,0 +1,18 @@
+namespace TestNamespace.SubNameSpace
+{
+    public class InnerClass
+    {
+        public InnerClass(int intParam1, int intParam2, int intParam3, string stringParam1, string stringParam2, string stringParam3)
+        {
+
+        }
+    }
+
+    public class OuterClass
+    {
+        public OuterClass(InnerClass innerClass)
+        {
+
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
@@ -465,6 +465,9 @@
   <ItemGroup>
     <None Include="Resources\AsyncMethod.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\RepeatedValueTypeParameters.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
@@ -209,11 +209,10 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         ///			return System.Threading.Tasks.Task.CompletedTask;
         ///	    }
         ///
-        ///	    public System.Threading.Tasks.Task&lt;int&gt; ThisIsAnAsyncMethod(string methodName, int methodValue)
+        ///	    public System.Threading.Tasks.Task&lt;int&gt; ThisIsAnAsyncMethodWithReturnType(string methodName, int methodValue)
         ///	    {
         ///		    System.Console.WriteLine(&quot;Testing this&quot;);
-        ///			return System.Threading.Tasks.Task.FromResult(0);
-        ///	     [rest of string was truncated]&quot;;.
+        ///			return System.Threading.Tasks.Task.FromRes [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AsyncMethod {
             get {
@@ -824,6 +823,15 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         internal static string RefAndOutParameters {
             get {
                 return ResourceManager.GetString("RefAndOutParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string RepeatedValueTypeParameters {
+            get {
+                return ResourceManager.GetString("RepeatedValueTypeParameters", resourceCulture);
             }
         }
         

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
@@ -199,6 +199,9 @@
   <data name="RefAndOutParameters" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\RefAndOutParameters.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="RepeatedValueTypeParameters" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RepeatedValueTypeParameters.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="SampleClassTestFile" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\SampleClassTestFile.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/SentryOne.UnitTestGenerator.Core/Helpers/AssignmentValueHelper.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Helpers/AssignmentValueHelper.cs
@@ -100,7 +100,11 @@
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 namedType.ToTypeSyntax(frameworkSet.Context),
                                 SyntaxFactory.IdentifierName(factoryMethod.Name)))
-                        .WithArgumentList(Generate.Arguments(factoryMethod.Parameters.Select(x => GetDefaultAssignmentValue(x.Type, semanticModel, visitedTypes, frameworkSet)).ToArray()));
+                        .WithArgumentList(Generate.Arguments(factoryMethod.Parameters.Select(x =>
+                        {
+                            var visitedTypesThisMember = new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase);
+                            return GetDefaultAssignmentValue(x.Type, semanticModel, visitedTypesThisMember, frameworkSet);
+                        }).OfType<CSharpSyntaxNode>().ToArray()));
                 }
 
                 var instanceProperty = namedType.GetMembers().OfType<IPropertySymbol>().FirstOrDefault(x => x.Type.Equals(namedType) && x.IsStatic);
@@ -117,7 +121,8 @@
 
             foreach (var parameter in constructor.Parameters)
             {
-                parameters.Add(GetDefaultAssignmentValue(parameter.Type, semanticModel, visitedTypes, frameworkSet));
+                var visitedTypesThisParameter = new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase);
+                parameters.Add(GetDefaultAssignmentValue(parameter.Type, semanticModel, visitedTypesThisParameter, frameworkSet));
             }
 
             return Generate.ObjectCreation(namedType.ToTypeSyntax(frameworkSet.Context), parameters.ToArray());


### PR DESCRIPTION
If a class (a) requires a class parameter (b), and b's constructor has multiple parameters of the same type, then the emitted code would use default(T) for the second and subsequent parameters of the same type. This PR fixes that, and closes #17 .