### PR TITLE
Feature/34 per folder settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,28 @@ _Note: The default for project naming is **‘{0}.Tests’**. For example, a pro
 
 _Note: The default for the class and file naming is **‘{0}Tests’**. For example, a class called **MyClass** would be associated with a test class called **MyClassTests**._
 
-## Other Options
+### Other Options
 
 * Control whether test projects are automatically created
 * Control whether references are automatically added to test projects
 * Control the version of the framework dependencies that’s used
 
 _Note: If these options are not set, the extension uses the latest version. This does not apply to NUnit 2 because NUnit 2 and NUnit 3 share the same NuGet package name and the NUnit 2 version will always be 2.6.4 if this is left blank._
+
+### Setting options per-solution
+
+You can set settings per-solution if you need to (for example if you work with some code that uses MSTest and some that uses NUnit). In order to do this, you can create a `.unitTestGeneratorConfig` file, which is formatted similarly to .editorConfig files, just without the file type heading.
+
+You can set any member of the [IGenerationOptions](https://github.com/sentryone/unittestgenerator/blob/master/src/SentryOne.UnitTestGenerator.Core/Options/IGenerationOptions.cs) or the [IVersioningOptions](https://github.com/sentryone/unittestgenerator/blob/master/src/SentryOne.UnitTestGenerator.Core/Options/IVersioningOptions.cs) interfaces using this method. For example, the following content in a `.unitTestGeneratorConfig` would set the test framework to MSTest, the mocking framework to NSubstitute and the test project naming convention to `<project_name>.UnitTests`:
+
+```
+test_project_naming={0}.UnitTests
+framework-type=MSTest
+MockingFrameworkType=NSubstitute
+```
+
+> Note that the formatting for the member names is case insensitive, and underscores and hyphens are ignored. Hence `frameworkType`, `framework-type`, `FRAMEWORK_TYPE` and `FRAME-WORK-TYPE` all resolve to the `FrameworkType` member of `IGenerationOptions`. The rules for file finding & resolution work exactly the same as they do for `.editorConfig` files - in short, all folders from the solution file to the root are searched for a `.unitTestGeneratorConfig` file, and files 'closer' to the solution file take precedence if the same option is set in more than one file.
+
+## Other Notes
 
 _**Important**: Currently the extension doesn’t handle automatically creating test projects for .NET Core apps. It works as expected with.NET framework and .NET Standard projects. For .NET Core apps, please create the test project manually. Adding test classes and methods works normally once the project is in place._

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/EditorConfigFieldMapperTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/EditorConfigFieldMapperTests.cs
@@ -1,0 +1,34 @@
+namespace SentryOne.UnitTestGenerator.Core.Tests.Options
+{
+    using System;
+    using System.Collections.Generic;
+    using NSubstitute;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public static class EditorConfigFieldMapperTests
+    {
+        [Test]
+        public static void CanCallApplyTo()
+        {
+            var fileConfiguration = new Dictionary<string, string> { { "test_project_naming", "SomeProject{0}" } };
+            var target = new MutableGenerationOptions(Substitute.For<IGenerationOptions>());
+            fileConfiguration.ApplyTo(target);
+            Assert.That(target.TestProjectNaming, Is.EqualTo("SomeProject{0}"));
+        }
+
+        [Test]
+        public static void CannotCallApplyToWithNullFileConfiguration()
+        {
+            var target = new MutableGenerationOptions(Substitute.For<IGenerationOptions>());
+            Assert.Throws<ArgumentNullException>(() => default(Dictionary<string, string>).ApplyTo(target));
+        }
+
+        [Test]
+        public static void CannotCallApplyToWithNullTarget()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>().ApplyTo(default(MutableGenerationOptions)));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableGenerationOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableGenerationOptionsTests.cs
@@ -1,0 +1,116 @@
+namespace SentryOne.UnitTestGenerator.Core.Tests.Options
+{
+    using System;
+    using NSubstitute;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public class MutableGenerationOptionsTests
+    {
+        private MutableGenerationOptions _testClass;
+        private IGenerationOptions _options;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _options = Substitute.For<IGenerationOptions>();
+            _testClass = new MutableGenerationOptions(_options);
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            _options.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
+            _options.MockingFrameworkType.Returns(MockingFrameworkType.Moq);
+            _options.CreateProjectAutomatically.Returns(false);
+            _options.AddReferencesAutomatically.Returns(true);
+            _options.AllowGenerationWithoutTargetProject.Returns(true);
+            _options.TestProjectNaming.Returns("tpn");
+            _options.TestFileNaming.Returns("tfn");
+            _options.TestTypeNaming.Returns("ttn");
+
+            var instance = new MutableGenerationOptions(_options);
+            Assert.That(instance, Is.Not.Null);
+
+            Assert.That(_testClass.FrameworkType, Is.EqualTo(_options.FrameworkType));
+            Assert.That(_testClass.MockingFrameworkType, Is.EqualTo(_options.MockingFrameworkType));
+            Assert.That(_testClass.CreateProjectAutomatically, Is.EqualTo(_options.CreateProjectAutomatically));
+            Assert.That(_testClass.AddReferencesAutomatically, Is.EqualTo(_options.AddReferencesAutomatically));
+            Assert.That(_testClass.AllowGenerationWithoutTargetProject, Is.EqualTo(_options.AllowGenerationWithoutTargetProject));
+            Assert.That(_testClass.TestProjectNaming, Is.EqualTo(_options.TestProjectNaming));
+            Assert.That(_testClass.TestFileNaming, Is.EqualTo(_options.TestFileNaming));
+            Assert.That(_testClass.TestTypeNaming, Is.EqualTo(_options.TestTypeNaming));
+        }
+
+        [Test]
+        public void CannotConstructWithNullOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MutableGenerationOptions(default(IGenerationOptions)));
+        }
+
+        [Test]
+        public void CanSetAndGetFrameworkType()
+        {
+            var testValue = TestFrameworkTypes.XUnit;
+            _testClass.FrameworkType = testValue;
+            Assert.That(_testClass.FrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMockingFrameworkType()
+        {
+            var testValue = MockingFrameworkType.Moq;
+            _testClass.MockingFrameworkType = testValue;
+            Assert.That(_testClass.MockingFrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetCreateProjectAutomatically()
+        {
+            var testValue = false;
+            _testClass.CreateProjectAutomatically = testValue;
+            Assert.That(_testClass.CreateProjectAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAddReferencesAutomatically()
+        {
+            var testValue = false;
+            _testClass.AddReferencesAutomatically = testValue;
+            Assert.That(_testClass.AddReferencesAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAllowGenerationWithoutTargetProject()
+        {
+            var testValue = true;
+            _testClass.AllowGenerationWithoutTargetProject = testValue;
+            Assert.That(_testClass.AllowGenerationWithoutTargetProject, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestProjectNaming()
+        {
+            var testValue = "TestValue2008824805";
+            _testClass.TestProjectNaming = testValue;
+            Assert.That(_testClass.TestProjectNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestFileNaming()
+        {
+            var testValue = "TestValue1629131383";
+            _testClass.TestFileNaming = testValue;
+            Assert.That(_testClass.TestFileNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestTypeNaming()
+        {
+            var testValue = "TestValue609453222";
+            _testClass.TestTypeNaming = testValue;
+            Assert.That(_testClass.TestTypeNaming, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableGenerationOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableGenerationOptionsTests.cs
@@ -30,9 +30,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Options
             _options.TestFileNaming.Returns("tfn");
             _options.TestTypeNaming.Returns("ttn");
 
-            var instance = new MutableGenerationOptions(_options);
-            Assert.That(instance, Is.Not.Null);
-
+            _testClass = new MutableGenerationOptions(_options);
             Assert.That(_testClass.FrameworkType, Is.EqualTo(_options.FrameworkType));
             Assert.That(_testClass.MockingFrameworkType, Is.EqualTo(_options.MockingFrameworkType));
             Assert.That(_testClass.CreateProjectAutomatically, Is.EqualTo(_options.CreateProjectAutomatically));

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableVersioningOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableVersioningOptionsTests.cs
@@ -30,9 +30,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Options
             _options.NSubstituteNugetPackageVersion.Returns("7");
             _options.RhinoMocksNugetPackageVersion.Returns("8");
 
-            var instance = new MutableVersioningOptions(_options);
-            Assert.That(instance, Is.Not.Null);
-
+            _testClass = new MutableVersioningOptions(_options);
             Assert.That(_testClass.NUnit2NugetPackageVersion, Is.EqualTo(_options.NUnit2NugetPackageVersion));
             Assert.That(_testClass.NUnit3NugetPackageVersion, Is.EqualTo(_options.NUnit3NugetPackageVersion));
             Assert.That(_testClass.XUnitNugetPackageVersion, Is.EqualTo(_options.XUnitNugetPackageVersion));

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableVersioningOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/MutableVersioningOptionsTests.cs
@@ -1,0 +1,116 @@
+namespace SentryOne.UnitTestGenerator.Core.Tests.Options
+{
+    using System;
+    using NSubstitute;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public class MutableVersioningOptionsTests
+    {
+        private MutableVersioningOptions _testClass;
+        private IVersioningOptions _options;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _options = Substitute.For<IVersioningOptions>();
+            _testClass = new MutableVersioningOptions(_options);
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            _options.NUnit2NugetPackageVersion.Returns("1");
+            _options.NUnit3NugetPackageVersion.Returns("2");
+            _options.XUnitNugetPackageVersion.Returns("3");
+            _options.MsTestNugetPackageVersion.Returns("4");
+            _options.FakeItEasyNugetPackageVersion.Returns("5");
+            _options.MoqNugetPackageVersion.Returns("6");
+            _options.NSubstituteNugetPackageVersion.Returns("7");
+            _options.RhinoMocksNugetPackageVersion.Returns("8");
+
+            var instance = new MutableVersioningOptions(_options);
+            Assert.That(instance, Is.Not.Null);
+
+            Assert.That(_testClass.NUnit2NugetPackageVersion, Is.EqualTo(_options.NUnit2NugetPackageVersion));
+            Assert.That(_testClass.NUnit3NugetPackageVersion, Is.EqualTo(_options.NUnit3NugetPackageVersion));
+            Assert.That(_testClass.XUnitNugetPackageVersion, Is.EqualTo(_options.XUnitNugetPackageVersion));
+            Assert.That(_testClass.MsTestNugetPackageVersion, Is.EqualTo(_options.MsTestNugetPackageVersion));
+            Assert.That(_testClass.FakeItEasyNugetPackageVersion, Is.EqualTo(_options.FakeItEasyNugetPackageVersion));
+            Assert.That(_testClass.MoqNugetPackageVersion, Is.EqualTo(_options.MoqNugetPackageVersion));
+            Assert.That(_testClass.NSubstituteNugetPackageVersion, Is.EqualTo(_options.NSubstituteNugetPackageVersion));
+            Assert.That(_testClass.RhinoMocksNugetPackageVersion, Is.EqualTo(_options.RhinoMocksNugetPackageVersion));
+        }
+
+        [Test]
+        public void CannotConstructWithNullOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MutableVersioningOptions(default(IVersioningOptions)));
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit2NugetPackageVersion()
+        {
+            var testValue = "TestValue1062178473";
+            _testClass.NUnit2NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit2NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit3NugetPackageVersion()
+        {
+            var testValue = "TestValue1330446902";
+            _testClass.NUnit3NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit3NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetXUnitNugetPackageVersion()
+        {
+            var testValue = "TestValue152547983";
+            _testClass.XUnitNugetPackageVersion = testValue;
+            Assert.That(_testClass.XUnitNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMsTestNugetPackageVersion()
+        {
+            var testValue = "TestValue966405659";
+            _testClass.MsTestNugetPackageVersion = testValue;
+            Assert.That(_testClass.MsTestNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetFakeItEasyNugetPackageVersion()
+        {
+            var testValue = "TestValue17506298";
+            _testClass.FakeItEasyNugetPackageVersion = testValue;
+            Assert.That(_testClass.FakeItEasyNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMoqNugetPackageVersion()
+        {
+            var testValue = "TestValue2013518628";
+            _testClass.MoqNugetPackageVersion = testValue;
+            Assert.That(_testClass.MoqNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNSubstituteNugetPackageVersion()
+        {
+            var testValue = "TestValue935604466";
+            _testClass.NSubstituteNugetPackageVersion = testValue;
+            Assert.That(_testClass.NSubstituteNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetRhinoMocksNugetPackageVersion()
+        {
+            var testValue = "TestValue1080525660";
+            _testClass.RhinoMocksNugetPackageVersion = testValue;
+            Assert.That(_testClass.RhinoMocksNugetPackageVersion, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/TypeMemberMutatorTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/TypeMemberMutatorTests.cs
@@ -1,0 +1,80 @@
+namespace SentryOne.UnitTestGenerator.Core.Tests.Options
+{
+    using SentryOne.UnitTestGenerator.Core.Options;
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TypeMemberMutatorTests
+    {
+        private class Target
+        {
+            public TestFrameworkTypes FrameworkType { get; set; }
+
+            public Guid TargetGuid { get; set; }
+
+            public string TargetString { get; set; }
+
+            public int TargetInt { get; set; }
+        }
+
+        private TypeMemberMutator _testClass;
+        private Type _targetType;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _targetType = typeof(Target);
+            _testClass = new TypeMemberMutator(_targetType);
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var instance = new TypeMemberMutator(_targetType);
+            Assert.That(instance, Is.Not.Null);
+        }
+
+        [Test]
+        public void CannotConstructWithNullTargetType()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TypeMemberMutator(default(Type)));
+        }
+
+        [Test]
+        public void CanCallSet()
+        {
+            var instance = new Target();
+            _testClass.Set(instance, nameof(Target.FrameworkType), nameof(TestFrameworkTypes.MsTest));
+            _testClass.Set(instance, nameof(Target.TargetGuid), "F371CA3F-3330-4975-9E13-2580CDDC89CD");
+            _testClass.Set(instance, nameof(Target.TargetString), "someString");
+            _testClass.Set(instance, nameof(Target.TargetInt), "13241");
+            Assert.That(instance.FrameworkType, Is.EqualTo(TestFrameworkTypes.MsTest));
+            Assert.That(instance.TargetGuid, Is.EqualTo(new Guid("F371CA3F-3330-4975-9E13-2580CDDC89CD")));
+            Assert.That(instance.TargetString, Is.EqualTo("someString"));
+            Assert.That(instance.TargetInt, Is.EqualTo(13241));
+        }
+
+        [Test]
+        public void CannotCallSetWithNullInstance()
+        {
+            Assert.Throws<ArgumentNullException>(() => _testClass.Set(default(object), "TestValue901544463", "TestValue570844002"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void CanCallSetWithInvalidFieldName(string value)
+        {
+            Assert.DoesNotThrow(() => _testClass.Set(new object(), value, "TestValue325869245"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void CanCallSetWithInvalidFieldValue(string value)
+        {
+            Assert.DoesNotThrow(() => _testClass.Set(new object(), "TestValue606729554", value));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
@@ -1,0 +1,84 @@
+namespace SentryOne.UnitTestGenerator.Core.Tests.Options
+{
+    using System;
+    using System.IO;
+    using NSubstitute;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public static class UnitTestGeneratorOptionsFactoryTests
+    {
+        [Test]
+        public static void CannotCallCreateWithNullGenerationOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", default(MutableGenerationOptions), Substitute.For<IVersioningOptions>()));
+        }
+
+        [Test]
+        public static void CannotCallCreateWithNullVersioningOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1891551318", Substitute.For<IGenerationOptions>(), default(MutableVersioningOptions)));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public static void CanCallCreateWithInvalidSolutionFilePath(string value)
+        {
+            Assert.DoesNotThrow(() => UnitTestGeneratorOptionsFactory.Create(value, Substitute.For<IGenerationOptions>(), Substitute.For<IVersioningOptions>()));
+        }
+
+        [Test]
+        public static void CreateLoadsConfigFiles()
+        {
+            string tempfolder = null;
+            try
+            {
+                while (true)
+                {
+                    try
+                    {
+                        tempfolder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                        Directory.CreateDirectory(tempfolder);
+                        break;
+                    }
+                    catch (IOException)
+                    {
+                    }
+                }
+
+                var pathA = Path.Combine(tempfolder, "a");
+                var pathB = Path.Combine(tempfolder, "a", "b");
+                var pathC = Path.Combine(tempfolder, "a", "b", "c");
+                Directory.CreateDirectory(pathC);
+
+                var solutionFilePath = Path.Combine(pathC, "someSolution.sln");
+                var generationOptions = Substitute.For<IGenerationOptions>();
+                generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
+                var versioningOptions = Substitute.For<IVersioningOptions>();
+
+                File.WriteAllText(Path.Combine(pathA, ".unitTestGeneratorConfig"), "framework-type=XUnit");
+                File.WriteAllText(Path.Combine(pathB, ".unitTestGeneratorConfig"), "framework-type=NUnit3");
+                File.WriteAllText(Path.Combine(pathC, ".unitTestGeneratorConfig"), "framework-type=NUnit2");
+
+                var result = UnitTestGeneratorOptionsFactory.Create(solutionFilePath, generationOptions, versioningOptions);
+                Assert.That(result.GenerationOptions.FrameworkType, Is.EqualTo(TestFrameworkTypes.NUnit2));
+                Assert.That(result.GenerationOptions.MockingFrameworkType, Is.EqualTo(MockingFrameworkType.NSubstitute));
+            }
+            finally
+            {
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(tempfolder))
+                    {
+                        Directory.Delete(tempfolder, true);
+                    }
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/AbstractSelfReferencingClass.txt
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/AbstractSelfReferencingClass.txt
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BasicProject
+{
+    public abstract class AbsTest
+    {
+        protected static string GetString()
+        {
+            return "string";
+        }
+
+        public AbsTest(IEnumerable<AbsTest> childSelectors)
+        {
+        }
+    }
+
+    public class AbsTestThing : AbsTest
+    {
+        public AbsTestThing() : base(Enumerable.Empty<AbsTest>())
+        {
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
@@ -48,6 +48,9 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="EditorConfig.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=fe6ce3ea283749f2, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\editorconfig.0.12.2\lib\net45\EditorConfig.Core.dll</HintPath>
+    </Reference>
     <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\FakeItEasy.5.1.1\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
@@ -287,8 +290,11 @@
     <Compile Include="Models\ReferencedAssemblyTests.cs" />
     <Compile Include="Models\SemanticVersionTests.cs" />
     <Compile Include="Models\TestableModelTests.cs" />
+    <Compile Include="Options\EditorConfigFieldMapperTests.cs" />
     <Compile Include="Options\MutableGenerationOptionsTests.cs" />
     <Compile Include="Options\MutableVersioningOptionsTests.cs" />
+    <Compile Include="Options\TypeMemberMutatorTests.cs" />
+    <Compile Include="Options\UnitTestGeneratorOptionsFactoryTests.cs" />
     <Compile Include="Options\UnitTestGeneratorOptionsTests.cs" />
     <Compile Include="Strategies\ClassGeneration\AbstractClassGenerationStrategyTests.cs" />
     <Compile Include="Strategies\ClassGeneration\ClassGenerationStrategyFactoryTests.cs" />

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
@@ -287,6 +287,8 @@
     <Compile Include="Models\ReferencedAssemblyTests.cs" />
     <Compile Include="Models\SemanticVersionTests.cs" />
     <Compile Include="Models\TestableModelTests.cs" />
+    <Compile Include="Options\MutableGenerationOptionsTests.cs" />
+    <Compile Include="Options\MutableVersioningOptionsTests.cs" />
     <Compile Include="Options\UnitTestGeneratorOptionsTests.cs" />
     <Compile Include="Strategies\ClassGeneration\AbstractClassGenerationStrategyTests.cs" />
     <Compile Include="Strategies\ClassGeneration\ClassGenerationStrategyFactoryTests.cs" />

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
@@ -479,6 +479,9 @@
   <ItemGroup>
     <None Include="Resources\MappingMethod.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AbstractSelfReferencingClass.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/EnumFactoryTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/EnumFactoryTests.cs
@@ -1,6 +1,7 @@
 namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.CodeAnalysis;
     using NSubstitute;
     using NUnit.Framework;
@@ -13,13 +14,13 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
         [Test]
         public static void CannotCallRandomWithNullTypeSymbol()
         {
-            Assert.Throws<ArgumentNullException>(() => EnumFactory.Random(default(ITypeSymbol), ClassModelProvider.Instance.SemanticModel, Substitute.For<IFrameworkSet>()));
+            Assert.Throws<ArgumentNullException>(() => EnumFactory.Random(default(ITypeSymbol), ClassModelProvider.Instance.SemanticModel, new HashSet<string>(StringComparer.OrdinalIgnoreCase), Substitute.For<IFrameworkSet>()));
         }
 
         [Test]
         public static void CannotCallRandomWithNullFrameworkSet()
         {
-            Assert.Throws<ArgumentNullException>(() => EnumFactory.Random(Substitute.For<ITypeSymbol>(), ClassModelProvider.Instance.SemanticModel, default(IFrameworkSet)));
+            Assert.Throws<ArgumentNullException>(() => EnumFactory.Random(Substitute.For<ITypeSymbol>(), ClassModelProvider.Instance.SemanticModel, new HashSet<string>(StringComparer.OrdinalIgnoreCase), default(IFrameworkSet)));
         }
     }
 }

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
@@ -1,6 +1,7 @@
 namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Scripting;
@@ -61,7 +62,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
             generationOptions.TestTypeNaming.Returns("{0}Tests");
             var options = new UnitTestGeneratorOptions(generationOptions, versionOptions);
             var frameworkSet = FrameworkSetFactory.Create(options);
-            var expression = ValueGenerationStrategyFactory.GenerateFor(info, model, frameworkSet);
+            var expression = ValueGenerationStrategyFactory.GenerateFor(info, model, new HashSet<string>(StringComparer.OrdinalIgnoreCase),  frameworkSet);
 
             string expressionText = string.Empty;
             try

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
@@ -35,6 +35,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
         [TestCase("System.Globalization.CultureInfo")]
         [TestCase("System.Byte[]")]
         [TestCase("System.IO.Stream")]
+        [TestCase("System.Threading.CancellationToken")]
         [TestCase("System.Drawing.Brush, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         [TestCase("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         [TestCase("System.Int32[]")] // System.Array
@@ -77,6 +78,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Strategies.ValueGeneration
                         .AddImports("System.Drawing")
                         .AddImports("Microsoft.Win32")
                         .AddImports("System.Globalization")
+                        .AddImports("System.Threading")
                         .AddImports("System.Collections");
                     var result = await CSharpScript.EvaluateAsync<object>(expressionText, scriptOptions).ConfigureAwait(false);
 

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
@@ -180,6 +180,15 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string AbstractSelfReferencingClass {
+            get {
+                return ResourceManager.GetString("AbstractSelfReferencingClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to public class TestClass
         ///    {
         ///		string _str1;
@@ -628,7 +637,25 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to namespace TestApp1
+        ///{
+        ///    public class InputClass
+        ///    {
+        ///        public string SomeProperty { get; }
+        ///        public string SomeOtherProperty { get; set; }
+        ///        public string WriteOnlyProperty { set { } }
+        ///    }
+        ///
+        ///    public class OutputClass
+        ///    {
+        ///        public string SomeProperty { get; set; }
+        ///        public string SomeOtherProperty { get; set; }
+        ///        public string WriteOnlyProperty { get; set; }
+        ///    }
+        ///    public class C3
+        ///    {
+        ///        public OutputClass Map(InputClass inputClass)
+        ///     [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string MappingMethod {
             get {

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
@@ -130,6 +130,9 @@
   <data name="AbstractProperty" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\AbstractProperty.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="AbstractSelfReferencingClass" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\AbstractSelfReferencingClass.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="ArrowPropertyGetter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ArrowPropertyGetter.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/packages.config
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
+  <package id="editorconfig" version="0.12.2" targetFramework="net461" />
   <package id="FakeItEasy" version="5.1.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.9.4" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.10.0" targetFramework="net461" />

--- a/src/SentryOne.UnitTestGenerator.Core/Options/EditorConfigFieldMapper.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/EditorConfigFieldMapper.cs
@@ -1,0 +1,23 @@
+﻿namespace SentryOne.UnitTestGenerator.Core.Options
+{
+    using System;
+    using System.Collections.Generic;
+    using EditorConfig.Core;
+
+    public static class EditorConfigFieldMapper
+    {
+        public static void ApplyTo<T>(this Dictionary<string, string> fileConfiguration, T target)
+        {
+            if (fileConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(fileConfiguration));
+            }
+
+            var mutator = new TypeMemberMutator(typeof(T));
+            foreach (var property in fileConfiguration)
+            {
+                mutator.Set(target, property.Key, property.Value);
+            }
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core/Options/EditorConfigFieldMapper.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/EditorConfigFieldMapper.cs
@@ -2,15 +2,20 @@
 {
     using System;
     using System.Collections.Generic;
-    using EditorConfig.Core;
 
     public static class EditorConfigFieldMapper
     {
         public static void ApplyTo<T>(this Dictionary<string, string> fileConfiguration, T target)
+            where T : class
         {
             if (fileConfiguration == null)
             {
                 throw new ArgumentNullException(nameof(fileConfiguration));
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
             }
 
             var mutator = new TypeMemberMutator(typeof(T));

--- a/src/SentryOne.UnitTestGenerator.Core/Options/MutableGenerationOptions.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/MutableGenerationOptions.cs
@@ -1,0 +1,40 @@
+﻿namespace SentryOne.UnitTestGenerator.Core.Options
+{
+    using System;
+
+    public class MutableGenerationOptions : IGenerationOptions
+    {
+        public MutableGenerationOptions(IGenerationOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            FrameworkType = options.FrameworkType;
+            MockingFrameworkType = options.MockingFrameworkType;
+            CreateProjectAutomatically = options.CreateProjectAutomatically;
+            AddReferencesAutomatically = options.AddReferencesAutomatically;
+            AllowGenerationWithoutTargetProject = options.AllowGenerationWithoutTargetProject;
+            TestProjectNaming = options.TestProjectNaming;
+            TestFileNaming = options.TestFileNaming;
+            TestTypeNaming = options.TestTypeNaming;
+        }
+
+        public TestFrameworkTypes FrameworkType { get; set; }
+
+        public MockingFrameworkType MockingFrameworkType { get; set; }
+
+        public bool CreateProjectAutomatically { get; set; }
+
+        public bool AddReferencesAutomatically { get; set; }
+
+        public bool AllowGenerationWithoutTargetProject { get; set; }
+
+        public string TestProjectNaming { get; set; }
+
+        public string TestFileNaming { get; set; }
+
+        public string TestTypeNaming { get; set; }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core/Options/MutableVersioningOptions.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/MutableVersioningOptions.cs
@@ -1,0 +1,40 @@
+﻿namespace SentryOne.UnitTestGenerator.Core.Options
+{
+    using System;
+
+    public class MutableVersioningOptions : IVersioningOptions
+    {
+        public MutableVersioningOptions(IVersioningOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            NUnit2NugetPackageVersion = options.NUnit2NugetPackageVersion;
+            NUnit3NugetPackageVersion = options.NUnit3NugetPackageVersion;
+            XUnitNugetPackageVersion = options.XUnitNugetPackageVersion;
+            MsTestNugetPackageVersion = options.MsTestNugetPackageVersion;
+            FakeItEasyNugetPackageVersion = options.FakeItEasyNugetPackageVersion;
+            MoqNugetPackageVersion = options.MoqNugetPackageVersion;
+            NSubstituteNugetPackageVersion = options.NSubstituteNugetPackageVersion;
+            RhinoMocksNugetPackageVersion = options.RhinoMocksNugetPackageVersion;
+        }
+
+        public string NUnit2NugetPackageVersion { get; set; }
+
+        public string NUnit3NugetPackageVersion { get; set; }
+
+        public string XUnitNugetPackageVersion { get; set; }
+
+        public string MsTestNugetPackageVersion { get; set; }
+
+        public string FakeItEasyNugetPackageVersion { get; set; }
+
+        public string MoqNugetPackageVersion { get; set; }
+
+        public string NSubstituteNugetPackageVersion { get; set; }
+
+        public string RhinoMocksNugetPackageVersion { get; set; }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core/Options/TypeMemberMutator.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/TypeMemberMutator.cs
@@ -41,16 +41,7 @@
                     {
                         member.SetValue(instance, Coerce(fieldValue, member.PropertyType));
                     }
-                    catch (TargetException)
-                    {
-                    }
-                    catch (MethodAccessException)
-                    {
-                    }
-                    catch (TargetInvocationException)
-                    {
-                    }
-                    catch (InvalidCastException)
+                    catch (Exception e) when (e is TargetException || e is MethodAccessException || e is TargetInvocationException || e is InvalidCastException)
                     {
                     }
 
@@ -61,11 +52,6 @@
 
         private static object Coerce(object convertibleValue, Type targetType)
         {
-            if (convertibleValue == null)
-            {
-                return null;
-            }
-
             try
             {
                 try

--- a/src/SentryOne.UnitTestGenerator.Core/Options/TypeMemberMutator.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/TypeMemberMutator.cs
@@ -1,0 +1,88 @@
+﻿namespace SentryOne.UnitTestGenerator.Core.Options
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+
+    public class TypeMemberMutator
+    {
+        private readonly Type _targetType;
+
+        public TypeMemberMutator(Type targetType)
+        {
+            if (targetType == null)
+            {
+                throw new ArgumentNullException(nameof(targetType));
+            }
+
+            _targetType = targetType;
+        }
+
+        public void Set(object instance, string fieldName, string fieldValue)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (string.IsNullOrWhiteSpace(fieldName) || string.IsNullOrWhiteSpace(fieldValue))
+            {
+                return;
+            }
+
+            var cleanFieldName = fieldName.Replace("_", string.Empty).Replace("-", string.Empty);
+            foreach (var member in _targetType.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.CanWrite))
+            {
+                if (string.Equals(member.Name, cleanFieldName, StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        member.SetValue(instance, Coerce(fieldValue, member.PropertyType));
+                    }
+                    catch (TargetException)
+                    {
+                    }
+                    catch (MethodAccessException)
+                    {
+                    }
+                    catch (TargetInvocationException)
+                    {
+                    }
+                    catch (InvalidCastException)
+                    {
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        private static object Coerce(object convertibleValue, Type targetType)
+        {
+            if (convertibleValue == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                try
+                {
+                    return Convert.ChangeType(convertibleValue, targetType, CultureInfo.InvariantCulture);
+                }
+                catch (Exception e) when (e is InvalidCastException || e is FormatException || e is OverflowException)
+                {
+                }
+
+                var descriptor = TypeDescriptor.GetConverter(targetType);
+                return descriptor.ConvertFromString(convertibleValue.ToString());
+            }
+            catch
+            {
+                throw new InvalidCastException(string.Format(CultureInfo.CurrentCulture, "Could not interpret the value '{0}' as type '{1}'.", convertibleValue, targetType.FullName));
+            }
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core/Options/UnitTestGeneratorOptionsFactory.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Options/UnitTestGeneratorOptionsFactory.cs
@@ -1,0 +1,42 @@
+﻿namespace SentryOne.UnitTestGenerator.Core.Options
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using EditorConfig.Core;
+
+    public static class UnitTestGeneratorOptionsFactory
+    {
+        public static IUnitTestGeneratorOptions Create(string solutionFilePath, IGenerationOptions generationOptions, IVersioningOptions versioningOptions)
+        {
+            if (generationOptions == null)
+            {
+                throw new ArgumentNullException(nameof(generationOptions));
+            }
+
+            if (versioningOptions == null)
+            {
+                throw new ArgumentNullException(nameof(versioningOptions));
+            }
+
+            var mutableGenerationOptions = new MutableGenerationOptions(generationOptions);
+            var mutableVersioningOptions = new MutableVersioningOptions(versioningOptions);
+
+            if (!string.IsNullOrWhiteSpace(solutionFilePath))
+            {
+                var allFiles = new EditorConfigParser(".unitTestGeneratorConfig").GetConfigurationFilesTillRoot(solutionFilePath);
+                var allProperties = allFiles.SelectMany(x => x.Sections).SelectMany(x => x);
+                var properties = new Dictionary<string, string>();
+                foreach (var pair in allProperties)
+                {
+                    properties[pair.Key] = pair.Value;
+                }
+
+                properties.ApplyTo(mutableGenerationOptions);
+                properties.ApplyTo(mutableVersioningOptions);
+            }
+
+            return new UnitTestGeneratorOptions(mutableGenerationOptions, mutableVersioningOptions);
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core/SentryOne.UnitTestGenerator.Core.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core/SentryOne.UnitTestGenerator.Core.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="editorconfig" Version="0.12.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ArrayFactory.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ArrayFactory.cs
@@ -1,5 +1,7 @@
 ﻿namespace SentryOne.UnitTestGenerator.Core.Strategies.ValueGeneration
 {
+    using System;
+    using System.Collections.Generic;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -8,32 +10,42 @@
 
     public static class ArrayFactory
     {
-        public static ExpressionSyntax ImplicitlyTypedArray(ITypeSymbol typeSymbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public static ExpressionSyntax ImplicitlyTypedArray(ITypeSymbol typeSymbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
             {
+                if (visitedTypes.Contains(arrayTypeSymbol.ElementType.ToFullName()))
+                {
+                    return SyntaxFactory.ArrayCreationExpression(SyntaxFactory.ArrayType(arrayTypeSymbol.ElementType.ToTypeSyntax(frameworkSet.Context)));
+                }
+
                 return SyntaxFactory.ImplicitArrayCreationExpression(
                     SyntaxFactory.InitializerExpression(
                         SyntaxKind.ArrayInitializerExpression,
                         SyntaxFactory.SeparatedList<ExpressionSyntax>(
                             new SyntaxNodeOrToken[]
                             {
-                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(arrayTypeSymbol.ElementType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                             })));
             }
 
             return AssignmentValueHelper.GetDefaultAssignmentValue(typeSymbol, model, frameworkSet);
         }
 
-        public static ExpressionSyntax ImplicitlyTyped(ITypeSymbol typeSymbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public static ExpressionSyntax ImplicitlyTyped(ITypeSymbol typeSymbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (typeSymbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.TypeArguments.Length > 0)
             {
                 var targetType = namedTypeSymbol.TypeArguments[0];
+
+                if (visitedTypes.Contains(targetType.ToFullName()))
+                {
+                    return SyntaxFactory.ArrayCreationExpression(SyntaxFactory.ArrayType(targetType.ToTypeSyntax(frameworkSet.Context)));
+                }
 
                 return SyntaxFactory.ImplicitArrayCreationExpression(
                     SyntaxFactory.InitializerExpression(
@@ -41,11 +53,11 @@
                         SyntaxFactory.SeparatedList<ExpressionSyntax>(
                             new SyntaxNodeOrToken[]
                             {
-                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, frameworkSet),
+                                AssignmentValueHelper.GetDefaultAssignmentValue(targetType, model, new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase), frameworkSet),
                             })));
             }
 

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/EnumFactory.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/EnumFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace SentryOne.UnitTestGenerator.Core.Strategies.ValueGeneration
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -10,7 +11,7 @@
 
     public static class EnumFactory
     {
-        public static ExpressionSyntax Random(ITypeSymbol typeSymbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public static ExpressionSyntax Random(ITypeSymbol typeSymbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (typeSymbol == null)
             {

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/IValueGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/IValueGenerationStrategy.cs
@@ -9,6 +9,6 @@
     {
         IEnumerable<string> SupportedTypeNames { get; }
 
-        ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, IFrameworkSet frameworkSet);
+        ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet);
     }
 }

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/SimpleValueGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/SimpleValueGenerationStrategy.cs
@@ -18,7 +18,7 @@
 
         public IEnumerable<string> SupportedTypeNames { get; }
 
-        public ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (symbol is null)
             {

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/TypedValueGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/TypedValueGenerationStrategy.cs
@@ -8,9 +8,9 @@
 
     public class TypedValueGenerationStrategy : IValueGenerationStrategy
     {
-        private readonly Func<ITypeSymbol, SemanticModel, IFrameworkSet, ExpressionSyntax> _factory;
+        private readonly Func<ITypeSymbol, SemanticModel, HashSet<string>, IFrameworkSet, ExpressionSyntax> _factory;
 
-        public TypedValueGenerationStrategy(Func<ITypeSymbol, SemanticModel, IFrameworkSet, ExpressionSyntax> factory, params string[] typeNames)
+        public TypedValueGenerationStrategy(Func<ITypeSymbol, SemanticModel, HashSet<string>, IFrameworkSet, ExpressionSyntax> factory, params string[] typeNames)
         {
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
             SupportedTypeNames = typeNames ?? throw new ArgumentNullException(nameof(typeNames));
@@ -18,7 +18,7 @@
 
         public IEnumerable<string> SupportedTypeNames { get; }
 
-        public ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public ExpressionSyntax CreateValueExpression(ITypeSymbol symbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (symbol is null)
             {
@@ -35,7 +35,7 @@
                 throw new ArgumentNullException(nameof(frameworkSet));
             }
 
-            return _factory(symbol, model, frameworkSet);
+            return _factory(symbol, model, visitedTypes, frameworkSet);
         }
     }
 }

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
@@ -32,6 +32,7 @@
                 new SimpleValueGenerationStrategy(() => Generate.Literal((float)(Random.NextDouble() * short.MaxValue)), "float", "float?"),
                 new SimpleValueGenerationStrategy(() => (Random.Next(int.MaxValue) % 2) > 0 ? Generate.Literal(true) : Generate.Literal(false), "bool", "bool?"),
                 new SimpleValueGenerationStrategy(() => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("CultureInfo"), SyntaxFactory.IdentifierName((Random.Next(int.MaxValue) % 2) > 0 ? "CurrentCulture" : "InvariantCulture")), "System.Globalization.CultureInfo"),
+                new SimpleValueGenerationStrategy(() => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("CancellationToken"), SyntaxFactory.IdentifierName("None")), "System.Threading.CancellationToken"),
                 new SimpleValueGenerationStrategy(ArrayFactory.Byte, "byte[]"),
                 new TypedValueGenerationStrategy(EnumFactory.Random, "System.Enum"),
                 new SimpleValueGenerationStrategy(() => Generate.ObjectCreation(SyntaxFactory.IdentifierName("MemoryStream")), "System.IO.Stream"),

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
@@ -45,12 +45,12 @@
                 new SimpleValueGenerationStrategy(BrushFactory.Colors, "System.Windows.Media.Color"),
             };
 
-        public static ExpressionSyntax GenerateFor(ITypeSymbol symbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public static ExpressionSyntax GenerateFor(ITypeSymbol symbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
-            return GenerateFor(symbol.ToFullName(), symbol, model, frameworkSet);
+            return GenerateFor(symbol.ToFullName(), symbol, model, visitedTypes, frameworkSet);
         }
 
-        public static ExpressionSyntax GenerateFor(string typeName, ITypeSymbol symbol, SemanticModel model, IFrameworkSet frameworkSet)
+        public static ExpressionSyntax GenerateFor(string typeName, ITypeSymbol symbol, SemanticModel model, HashSet<string> visitedTypes, IFrameworkSet frameworkSet)
         {
             if (symbol == null)
             {
@@ -60,7 +60,7 @@
             var strategy = Strategies.FirstOrDefault(x => x.SupportedTypeNames.Any(t => string.Equals(t, typeName, StringComparison.OrdinalIgnoreCase)));
             if (strategy != null)
             {
-                return strategy.CreateValueExpression(symbol, model, frameworkSet);
+                return strategy.CreateValueExpression(symbol, model, visitedTypes, frameworkSet);
             }
 
             var baseType = symbol.BaseType;
@@ -70,7 +70,7 @@
                 strategy = Strategies.FirstOrDefault(x => x.SupportedTypeNames.Any(t => string.Equals(t, name, StringComparison.OrdinalIgnoreCase)));
                 if (strategy != null)
                 {
-                    return strategy.CreateValueExpression(symbol, model, frameworkSet);
+                    return strategy.CreateValueExpression(symbol, model, visitedTypes, frameworkSet);
                 }
 
                 baseType = baseType.BaseType;

--- a/src/SentryOne.UnitTestGenerator.Specs/Strategies/MethodGeneration/CanCallMethodGeneration.feature
+++ b/src/SentryOne.UnitTestGenerator.Specs/Strategies/MethodGeneration/CanCallMethodGeneration.feature
@@ -5,6 +5,8 @@
 Scenario: Can Call Method Generation
 	Given I have a class defined as 
 	"""
+using System.Threading;
+
 public class TestClass
 {
 	public void Test1(out string tester)
@@ -15,6 +17,10 @@ public class TestClass
 	public void Test2(ref string tester)
 	{
 		tester = "test"
+	}
+
+	public void Test3(CancellationToken token)
+	{
 	}
 
     public TestClass(string stringProp, ITest iTest)
@@ -69,4 +75,9 @@ public class TestClass
 	And I expect a method called 'CanCallTest2'
 		And I expect it to contain the variable 'tester'
 		And I expect it to contain the statement '_testClass.Test2(reftester);'
+		And I expect it to contain the statement 'Assert.Fail("Create or modify test");'
+	And I expect a method called 'CanCallTest3'
+		And I expect it to contain the variable 'token'
+		And I expect it to contain the statement 'var token = CancellationToken.None;'
+		And I expect it to contain the statement '_testClass.Test3(token);'
 		And I expect it to contain the statement 'Assert.Fail("Create or modify test");'

--- a/src/SentryOne.UnitTestGenerator.Specs/Strategies/MethodGeneration/CanCallMethodGeneration.feature.cs
+++ b/src/SentryOne.UnitTestGenerator.Specs/Strategies/MethodGeneration/CanCallMethodGeneration.feature.cs
@@ -79,7 +79,9 @@ this.ScenarioInitialize(scenarioInfo);
             this.ScenarioStart();
 #line hidden
 #line 6
- testRunner.Given("I have a class defined as", @"public class TestClass
+ testRunner.Given("I have a class defined as", @"using System.Threading;
+
+public class TestClass
 {
 public void Test1(out string tester)
 {
@@ -89,6 +91,10 @@ public void Test1(out string tester)
 public void Test2(ref string tester)
 {
 	tester = ""test""
+}
+
+public void Test3(CancellationToken token)
+{
 }
 
    public TestClass(string stringProp, ITest iTest)
@@ -125,44 +131,54 @@ public void Test2(ref string tester)
 
    public TestClass ThisClass {get;set;}
 }", ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 55
+#line 61
  testRunner.And("I set my test framework to \'MS Test\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 56
+#line 62
  testRunner.And("I set my mock framework to \'FakeItEasy\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 57
+#line 63
  testRunner.When("I generate tests for the method using the strategy \'CanCallMethodGenerationStrate" +
                     "gy\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 58
+#line 64
  testRunner.Then("I expect a method called \'CanCallThisIsAMethod\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 59
+#line 65
   testRunner.And("I expect it to contain the variable \'methodName\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 60
+#line 66
   testRunner.And("I expect it to contain the statement \'_testClass.ThisIsAMethod(methodName, method" +
                     "Value);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 61
+#line 67
   testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 62
+#line 68
  testRunner.And("I expect a method called \'CanCallWillReturnAString\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 63
+#line 69
   testRunner.And("I expect it to have the attribute \'TestMethod\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 64
+#line 70
   testRunner.And("I expect it to contain the statement \'var result = _testClass.WillReturnAString()" +
                     ";\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 65
-  testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 66
- testRunner.And("I expect a method called \'CanCallTest1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 67
-  testRunner.And("I expect it to contain the statement \'_testClass.Test1(outvartester);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 68
-  testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 69
- testRunner.And("I expect a method called \'CanCallTest2\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 70
-  testRunner.And("I expect it to contain the variable \'tester\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 71
-  testRunner.And("I expect it to contain the statement \'_testClass.Test2(reftester);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+  testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 72
+ testRunner.And("I expect a method called \'CanCallTest1\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 73
+  testRunner.And("I expect it to contain the statement \'_testClass.Test1(outvartester);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 74
+  testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 75
+ testRunner.And("I expect a method called \'CanCallTest2\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 76
+  testRunner.And("I expect it to contain the variable \'tester\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 77
+  testRunner.And("I expect it to contain the statement \'_testClass.Test2(reftester);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 78
+  testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 79
+ testRunner.And("I expect a method called \'CanCallTest3\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 80
+  testRunner.And("I expect it to contain the variable \'token\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 81
+  testRunner.And("I expect it to contain the statement \'var token = CancellationToken.None;\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 82
+  testRunner.And("I expect it to contain the statement \'_testClass.Test3(token);\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 83
   testRunner.And("I expect it to contain the statement \'Assert.Fail(\"Create or modify test\");\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/SentryOne.UnitTestGenerator.Tests/Options/GenerationOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Tests/Options/GenerationOptionsTests.cs
@@ -1,0 +1,90 @@
+namespace SentryOne.UnitTestGenerator.Tests.Options
+{
+    using SentryOne.UnitTestGenerator.Options;
+    using System;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public class GenerationOptionsTests
+    {
+        private GenerationOptions _testClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testClass = new GenerationOptions();
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var instance = new GenerationOptions();
+            Assert.That(instance, Is.Not.Null);
+        }
+
+        [Test]
+        public void CanSetAndGetFrameworkType()
+        {
+            var testValue = TestFrameworkTypes.NUnit2;
+            _testClass.FrameworkType = testValue;
+            Assert.That(_testClass.FrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMockingFrameworkType()
+        {
+            var testValue = MockingFrameworkType.FakeItEasy;
+            _testClass.MockingFrameworkType = testValue;
+            Assert.That(_testClass.MockingFrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetCreateProjectAutomatically()
+        {
+            var testValue = false;
+            _testClass.CreateProjectAutomatically = testValue;
+            Assert.That(_testClass.CreateProjectAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAddReferencesAutomatically()
+        {
+            var testValue = false;
+            _testClass.AddReferencesAutomatically = testValue;
+            Assert.That(_testClass.AddReferencesAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAllowGenerationWithoutTargetProject()
+        {
+            var testValue = true;
+            _testClass.AllowGenerationWithoutTargetProject = testValue;
+            Assert.That(_testClass.AllowGenerationWithoutTargetProject, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestProjectNaming()
+        {
+            var testValue = "TestValue106238151";
+            _testClass.TestProjectNaming = testValue;
+            Assert.That(_testClass.TestProjectNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestFileNaming()
+        {
+            var testValue = "TestValue2110409327";
+            _testClass.TestFileNaming = testValue;
+            Assert.That(_testClass.TestFileNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestTypeNaming()
+        {
+            var testValue = "TestValue18585459";
+            _testClass.TestTypeNaming = testValue;
+            Assert.That(_testClass.TestTypeNaming, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Tests/Options/Internal/InternalGenerationOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Tests/Options/Internal/InternalGenerationOptionsTests.cs
@@ -1,0 +1,113 @@
+namespace SentryOne.UnitTestGenerator.Tests.Options.Internal
+{
+    using SentryOne.UnitTestGenerator.Options.Internal;
+    using System;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Options;
+    using SentryOne.UnitTestGenerator.Core.Options;
+
+    [TestFixture]
+    public class InternalGenerationOptionsTests
+    {
+        private InternalGenerationOptions _testClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testClass = new InternalGenerationOptions(new GenerationOptions { FrameworkType = TestFrameworkTypes.MsTest, MockingFrameworkType = MockingFrameworkType.Moq, CreateProjectAutomatically = false, AddReferencesAutomatically = true, AllowGenerationWithoutTargetProject = false, TestProjectNaming = "TestValue1764251425", TestFileNaming = "TestValue820933084", TestTypeNaming = "TestValue932260225" });
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var options = new GenerationOptions { FrameworkType = TestFrameworkTypes.NUnit3, MockingFrameworkType = MockingFrameworkType.NSubstitute, CreateProjectAutomatically = true, AddReferencesAutomatically = false, AllowGenerationWithoutTargetProject = false, TestProjectNaming = "TestValue460938778", TestFileNaming = "TestValue2008872683", TestTypeNaming = "TestValue1485974937" };
+            var result = new InternalGenerationOptions(options);
+            Assert.Fail("Create or modify test");
+        }
+
+        [Test]
+        public void CannotConstructWithNullOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => new InternalGenerationOptions(default(GenerationOptions)));
+        }
+
+        [Test]
+        public void ConstructorPerformsMapping()
+        {
+            var options = new GenerationOptions { FrameworkType = TestFrameworkTypes.NUnit3, MockingFrameworkType = MockingFrameworkType.Moq, CreateProjectAutomatically = true, AddReferencesAutomatically = true, AllowGenerationWithoutTargetProject = false, TestProjectNaming = "TestValue1144105985", TestFileNaming = "TestValue1370175379", TestTypeNaming = "TestValue1673837291" };
+            var result = new InternalGenerationOptions(options);
+            Assert.That(result.FrameworkType, Is.EqualTo(options.FrameworkType));
+            Assert.That(result.MockingFrameworkType, Is.EqualTo(options.MockingFrameworkType));
+            Assert.That(result.CreateProjectAutomatically, Is.EqualTo(options.CreateProjectAutomatically));
+            Assert.That(result.AddReferencesAutomatically, Is.EqualTo(options.AddReferencesAutomatically));
+            Assert.That(result.AllowGenerationWithoutTargetProject, Is.EqualTo(options.AllowGenerationWithoutTargetProject));
+            Assert.That(result.TestProjectNaming, Is.EqualTo(options.TestProjectNaming));
+            Assert.That(result.TestFileNaming, Is.EqualTo(options.TestFileNaming));
+            Assert.That(result.TestTypeNaming, Is.EqualTo(options.TestTypeNaming));
+        }
+
+        [Test]
+        public void CanSetAndGetFrameworkType()
+        {
+            var testValue = TestFrameworkTypes.NUnit2;
+            _testClass.FrameworkType = testValue;
+            Assert.That(_testClass.FrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMockingFrameworkType()
+        {
+            var testValue = MockingFrameworkType.FakeItEasy;
+            _testClass.MockingFrameworkType = testValue;
+            Assert.That(_testClass.MockingFrameworkType, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetCreateProjectAutomatically()
+        {
+            var testValue = false;
+            _testClass.CreateProjectAutomatically = testValue;
+            Assert.That(_testClass.CreateProjectAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAddReferencesAutomatically()
+        {
+            var testValue = true;
+            _testClass.AddReferencesAutomatically = testValue;
+            Assert.That(_testClass.AddReferencesAutomatically, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetAllowGenerationWithoutTargetProject()
+        {
+            var testValue = true;
+            _testClass.AllowGenerationWithoutTargetProject = testValue;
+            Assert.That(_testClass.AllowGenerationWithoutTargetProject, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestProjectNaming()
+        {
+            var testValue = "TestValue1235560686";
+            _testClass.TestProjectNaming = testValue;
+            Assert.That(_testClass.TestProjectNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestFileNaming()
+        {
+            var testValue = "TestValue807903778";
+            _testClass.TestFileNaming = testValue;
+            Assert.That(_testClass.TestFileNaming, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetTestTypeNaming()
+        {
+            var testValue = "TestValue1233864319";
+            _testClass.TestTypeNaming = testValue;
+            Assert.That(_testClass.TestTypeNaming, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Tests/Options/Internal/InternalVersioningOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Tests/Options/Internal/InternalVersioningOptionsTests.cs
@@ -1,0 +1,98 @@
+namespace SentryOne.UnitTestGenerator.Tests.Options.Internal
+{
+    using SentryOne.UnitTestGenerator.Options.Internal;
+    using System;
+    using NUnit.Framework;
+    using SentryOne.UnitTestGenerator.Options;
+
+    [TestFixture]
+    public class InternalVersioningOptionsTests
+    {
+        private InternalVersioningOptions _testClass;
+        private VersioningOptions _options;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _options = new VersioningOptions { NUnit2NugetPackageVersion = "TestValue442570332", NUnit3NugetPackageVersion = "TestValue1492007113", XUnitNugetPackageVersion = "TestValue158211288", MsTestNugetPackageVersion = "TestValue1542947643", FakeItEasyNugetPackageVersion = "TestValue2052952067", MoqNugetPackageVersion = "TestValue1973157387", NSubstituteNugetPackageVersion = "TestValue2125707732", RhinoMocksNugetPackageVersion = "TestValue9980845" };
+            _testClass = new InternalVersioningOptions(_options);
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var instance = new InternalVersioningOptions(_options);
+            Assert.That(instance, Is.Not.Null);
+        }
+
+        [Test]
+        public void CannotConstructWithNullOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => new InternalVersioningOptions(default(VersioningOptions)));
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit2NugetPackageVersion()
+        {
+            var testValue = "TestValue1576687523";
+            _testClass.NUnit2NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit2NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit3NugetPackageVersion()
+        {
+            var testValue = "TestValue1678457956";
+            _testClass.NUnit3NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit3NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetXUnitNugetPackageVersion()
+        {
+            var testValue = "TestValue1646992244";
+            _testClass.XUnitNugetPackageVersion = testValue;
+            Assert.That(_testClass.XUnitNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMsTestNugetPackageVersion()
+        {
+            var testValue = "TestValue1625777022";
+            _testClass.MsTestNugetPackageVersion = testValue;
+            Assert.That(_testClass.MsTestNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetFakeItEasyNugetPackageVersion()
+        {
+            var testValue = "TestValue2116618120";
+            _testClass.FakeItEasyNugetPackageVersion = testValue;
+            Assert.That(_testClass.FakeItEasyNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMoqNugetPackageVersion()
+        {
+            var testValue = "TestValue634295081";
+            _testClass.MoqNugetPackageVersion = testValue;
+            Assert.That(_testClass.MoqNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNSubstituteNugetPackageVersion()
+        {
+            var testValue = "TestValue1735732753";
+            _testClass.NSubstituteNugetPackageVersion = testValue;
+            Assert.That(_testClass.NSubstituteNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetRhinoMocksNugetPackageVersion()
+        {
+            var testValue = "TestValue1731365463";
+            _testClass.RhinoMocksNugetPackageVersion = testValue;
+            Assert.That(_testClass.RhinoMocksNugetPackageVersion, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Tests/Options/VersioningOptionsTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Tests/Options/VersioningOptionsTests.cs
@@ -1,0 +1,89 @@
+namespace SentryOne.UnitTestGenerator.Tests.Options
+{
+    using SentryOne.UnitTestGenerator.Options;
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class VersioningOptionsTests
+    {
+        private VersioningOptions _testClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testClass = new VersioningOptions();
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var instance = new VersioningOptions();
+            Assert.That(instance, Is.Not.Null);
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit2NugetPackageVersion()
+        {
+            var testValue = "TestValue354452418";
+            _testClass.NUnit2NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit2NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNUnit3NugetPackageVersion()
+        {
+            var testValue = "TestValue275178333";
+            _testClass.NUnit3NugetPackageVersion = testValue;
+            Assert.That(_testClass.NUnit3NugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetXUnitNugetPackageVersion()
+        {
+            var testValue = "TestValue1126599687";
+            _testClass.XUnitNugetPackageVersion = testValue;
+            Assert.That(_testClass.XUnitNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMsTestNugetPackageVersion()
+        {
+            var testValue = "TestValue1504140398";
+            _testClass.MsTestNugetPackageVersion = testValue;
+            Assert.That(_testClass.MsTestNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetFakeItEasyNugetPackageVersion()
+        {
+            var testValue = "TestValue738232825";
+            _testClass.FakeItEasyNugetPackageVersion = testValue;
+            Assert.That(_testClass.FakeItEasyNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetMoqNugetPackageVersion()
+        {
+            var testValue = "TestValue1496856104";
+            _testClass.MoqNugetPackageVersion = testValue;
+            Assert.That(_testClass.MoqNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetNSubstituteNugetPackageVersion()
+        {
+            var testValue = "TestValue1026683030";
+            _testClass.NSubstituteNugetPackageVersion = testValue;
+            Assert.That(_testClass.NSubstituteNugetPackageVersion, Is.EqualTo(testValue));
+        }
+
+        [Test]
+        public void CanSetAndGetRhinoMocksNugetPackageVersion()
+        {
+            var testValue = "TestValue301035158";
+            _testClass.RhinoMocksNugetPackageVersion = testValue;
+            Assert.That(_testClass.RhinoMocksNugetPackageVersion, Is.EqualTo(testValue));
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Tests/SentryOne.UnitTestGenerator.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Tests/SentryOne.UnitTestGenerator.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Class1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SentryOne.UnitTestGenerator\SentryOne.UnitTestGenerator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SentryOne.UnitTestGenerator/Commands/GenerateTestForSymbolCommand.cs
+++ b/src/SentryOne.UnitTestGenerator/Commands/GenerateTestForSymbolCommand.cs
@@ -210,20 +210,21 @@
 
                 var item = VsProjectHelper.GetProjectItem(document.FilePath);
 
-                var source = new ProjectItemModel(item, _package.Options.GenerationOptions);
+                var options = _package.Options;
+                var source = new ProjectItemModel(item, options.GenerationOptions);
 
                 var projectItem = source.Item;
 
                 var nameParts = VsProjectHelper.GetNameParts(projectItem);
 
-                if (source.TargetProject == null && _package.Options.GenerationOptions.CreateProjectAutomatically)
+                if (source.TargetProject == null && options.GenerationOptions.CreateProjectAutomatically)
                 {
-                    var testProject = SolutionUtilities.CreateTestProjectInCurrentSolution(_dte, source.Project, _package.Options.GenerationOptions);
-                    ReferencesHelper.AddNugetPackagesToProject(testProject, StandardReferenceHelper.GetReferencedNugetPackages(_package.Options), messageLogger.LogMessage, _package);
+                    var testProject = SolutionUtilities.CreateTestProjectInCurrentSolution(_dte, source.Project, options.GenerationOptions);
+                    ReferencesHelper.AddNugetPackagesToProject(testProject, StandardReferenceHelper.GetReferencedNugetPackages(options), messageLogger.LogMessage, _package);
                 }
 
                 var targetProject = source.TargetProject;
-                if (targetProject == null && !_package.Options.GenerationOptions.AllowGenerationWithoutTargetProject)
+                if (targetProject == null && !options.GenerationOptions.AllowGenerationWithoutTargetProject)
                 {
                     throw new InvalidOperationException("Cannot create tests for '" + Path.GetFileName(source.FilePath) + "' because there is no project '" + source.TargetProjectName + "'");
                 }
@@ -237,7 +238,7 @@
                 }
 
                 var targetProjectItems = TargetFinder.FindTargetFolder(targetProject, nameParts, true, out var targetPath);
-                if (targetProjectItems == null && !_package.Options.GenerationOptions.AllowGenerationWithoutTargetProject)
+                if (targetProjectItems == null && !options.GenerationOptions.AllowGenerationWithoutTargetProject)
                 {
                     // we asked to create targetProjectItems - so if it's null we effectively had a problem getting to the target project
                     throw new InvalidOperationException("Cannot create tests for '" + Path.GetFileName(source.FilePath) + "' because there is no project '" + source.TargetProjectName + "'");
@@ -264,7 +265,7 @@
                                 namespaceTransform = x => x + ".Tests";
                             }
 
-                            generationItem = new GenerationItem(source, methodSymbol.Item1, targetProjectItems, targetPath, set, assemblyReferences, namespaceTransform, _package.Options.GenerationOptions);
+                            generationItem = new GenerationItem(source, methodSymbol.Item1, targetProjectItems, targetPath, set, assemblyReferences, namespaceTransform, options.GenerationOptions);
 
                             await CodeGenerator.GenerateCodeAsync(new[] { generationItem }, withRegeneration, _package, projectDictionary, messageLogger).ConfigureAwait(true);
                         }

--- a/src/SentryOne.UnitTestGenerator/Commands/GenerationItem.cs
+++ b/src/SentryOne.UnitTestGenerator/Commands/GenerationItem.cs
@@ -53,7 +53,6 @@
 
                 return Path.Combine(_targetPath, targetFileName);
             }
-
         }
 
         public ProjectItems TargetProjectItems { get; }

--- a/src/SentryOne.UnitTestGenerator/Commands/GoToUnitTestsCommand.cs
+++ b/src/SentryOne.UnitTestGenerator/Commands/GoToUnitTestsCommand.cs
@@ -7,6 +7,7 @@
     using EnvDTE80;
     using Microsoft.VisualStudio.Shell;
     using SentryOne.UnitTestGenerator.Helper;
+    using SentryOne.UnitTestGenerator.Options;
     using Task = System.Threading.Tasks.Task;
 
     /// <summary>
@@ -85,13 +86,14 @@
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                var source = SolutionUtilities.GetSelectedFiles(_dte, false, _package.Options.GenerationOptions).FirstOrDefault(ProjectItemModel.IsSupported);
+                var options = _package.Options;
+                var source = SolutionUtilities.GetSelectedFiles(_dte, false, options.GenerationOptions).FirstOrDefault(ProjectItemModel.IsSupported);
                 if (source == null)
                 {
                     throw new InvalidOperationException("Cannot go to tests for this item because no supported files were found");
                 }
 
-                var status = TargetFinder.FindExistingTargetItem(source, _package.Options.GenerationOptions, out var targetItem);
+                var status = TargetFinder.FindExistingTargetItem(source, options.GenerationOptions, out var targetItem);
                 switch (status)
                 {
                     case FindTargetStatus.FileNotFound:

--- a/src/SentryOne.UnitTestGenerator/Commands/GoToUnitTestsForSymbolCommand.cs
+++ b/src/SentryOne.UnitTestGenerator/Commands/GoToUnitTestsForSymbolCommand.cs
@@ -102,9 +102,10 @@
 
                 var item = VsProjectHelper.GetProjectItem(document.FilePath);
 
-                var source = new ProjectItemModel(item, _package.Options.GenerationOptions);
+                var options = _package.Options;
+                var source = new ProjectItemModel(item, options.GenerationOptions);
 
-                var status = TargetFinder.FindExistingTargetItem(source, _package.Options.GenerationOptions, out var targetItem);
+                var status = TargetFinder.FindExistingTargetItem(source, options.GenerationOptions, out var targetItem);
                 switch (status)
                 {
                     case FindTargetStatus.FileNotFound:

--- a/src/SentryOne.UnitTestGenerator/Helper/CodeGenerator.cs
+++ b/src/SentryOne.UnitTestGenerator/Helper/CodeGenerator.cs
@@ -15,6 +15,7 @@
     using SentryOne.UnitTestGenerator.Core.Assets;
     using SentryOne.UnitTestGenerator.Core.Helpers;
     using SentryOne.UnitTestGenerator.Core.Models;
+    using SentryOne.UnitTestGenerator.Core.Options;
     using SentryOne.UnitTestGenerator.Properties;
     using Project = EnvDTE.Project;
     using Solution = Microsoft.CodeAnalysis.Solution;
@@ -25,10 +26,11 @@
         public static async Task GenerateCodeAsync(IReadOnlyCollection<GenerationItem> generationItems, bool withRegeneration, IUnitTestGeneratorPackage package, Dictionary<Project, Tuple<HashSet<TargetAsset>, HashSet<IReferencedAssembly>>> requiredAssetsByProject, IMessageLogger messageLogger)
         {
             var solution = package.Workspace.CurrentSolution;
+            var options = package.Options;
 
             foreach (var generationItem in generationItems)
             {
-                await GenerateItemAsync(withRegeneration, package, solution, generationItem).ConfigureAwait(true);
+                await GenerateItemAsync(withRegeneration, options, solution, generationItem).ConfigureAwait(true);
             }
 
             await package.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -41,9 +43,9 @@
                 messageLogger.LogMessage("Adding required assets to target project...");
                 foreach (var pair in requiredAssetsByProject)
                 {
-                    AddTargetAssets(package, pair);
+                    AddTargetAssets(options, pair);
 
-                    if (package.Options.GenerationOptions.AddReferencesAutomatically)
+                    if (options.GenerationOptions.AddReferencesAutomatically)
                     {
                         ReferencesHelper.AddReferencesToProject(pair.Key, pair.Value.Item2.ToList(), messageLogger.LogMessage);
                     }
@@ -59,7 +61,7 @@
                 {
                     if (generationItem.TargetProjectItems != null)
                     {
-                        AddTargetItem(generationItems, package, generationItem);
+                        AddTargetItem(generationItems, options, generationItem);
                     }
                     else
                     {
@@ -97,10 +99,10 @@
             }
         }
 
-        private static void AddTargetItem(IReadOnlyCollection<GenerationItem> generationItems, IUnitTestGeneratorPackage package, GenerationItem generationItem)
+        private static void AddTargetItem(IReadOnlyCollection<GenerationItem> generationItems, IUnitTestGeneratorOptions options, GenerationItem generationItem)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (TargetFinder.FindExistingTargetItem(generationItem.Source, package.Options.GenerationOptions, out var targetItem) != FindTargetStatus.Found)
+            if (TargetFinder.FindExistingTargetItem(generationItem.Source, options.GenerationOptions, out var targetItem) != FindTargetStatus.Found)
             {
                 File.WriteAllText(generationItem.TargetFileName, generationItem.TargetContent);
                 targetItem = generationItem.TargetProjectItems.AddFromFile(generationItem.TargetFileName);
@@ -126,7 +128,7 @@
             }
         }
 
-        private static void AddTargetAssets(IUnitTestGeneratorPackage package, KeyValuePair<Project, Tuple<HashSet<TargetAsset>, HashSet<IReferencedAssembly>>> pair)
+        private static void AddTargetAssets(IUnitTestGeneratorOptions options, KeyValuePair<Project, Tuple<HashSet<TargetAsset>, HashSet<IReferencedAssembly>>> pair)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             foreach (var targetAsset in pair.Value.Item1)
@@ -148,14 +150,14 @@
                     {
                         var nameSpace = VsProjectHelper.GetProjectRootNamespace(pair.Key);
                         var fileName = Path.Combine(targetProjectPath, asset.AssetFileName);
-                        File.WriteAllText(fileName, asset.Content(nameSpace, package.Options.GenerationOptions.FrameworkType));
+                        File.WriteAllText(fileName, asset.Content(nameSpace, options.GenerationOptions.FrameworkType));
                         pair.Key.ProjectItems.AddFromFile(fileName);
                     }
                 }
             }
         }
 
-        private static async Task GenerateItemAsync(bool withRegeneration, IUnitTestGeneratorPackage package, Solution solution, GenerationItem generationItem)
+        private static async Task GenerateItemAsync(bool withRegeneration, IUnitTestGeneratorOptions options, Solution solution, GenerationItem generationItem)
         {
             var targetProject = solution.Projects.FirstOrDefault(x => string.Equals(x.Name, generationItem.Source.Project.Name, StringComparison.Ordinal));
             var documents = solution.GetDocumentIdsWithFilePath(generationItem.Source.FilePath);
@@ -175,7 +177,7 @@
                 return;
             }
 
-            var result = await GenerateAsync(withRegeneration, package, solution, generationItem, semanticModel).ConfigureAwait(true);
+            var result = await GenerateAsync(withRegeneration, options, solution, generationItem, semanticModel).ConfigureAwait(true);
 
             generationItem.TargetContent = result.FileContent;
 
@@ -193,7 +195,7 @@
             }
         }
 
-        private static async Task<GenerationResult> GenerateAsync(bool withRegeneration, IUnitTestGeneratorPackage package, Solution solution, GenerationItem generationItem, SemanticModel semanticModel)
+        private static async Task<GenerationResult> GenerateAsync(bool withRegeneration, IUnitTestGeneratorOptions options, Solution solution, GenerationItem generationItem, SemanticModel semanticModel)
         {
             GenerationResult result;
             if (File.Exists(generationItem.TargetFileName))
@@ -205,16 +207,16 @@
 
                     var targetSemanticModel = await targetDocument.GetSemanticModelAsync().ConfigureAwait(true);
 
-                    result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, targetSemanticModel, withRegeneration, package.Options, generationItem.NamespaceTransform).ConfigureAwait(true);
+                    result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, targetSemanticModel, withRegeneration, options, generationItem.NamespaceTransform).ConfigureAwait(true);
                 }
                 else
                 {
-                    result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, null, withRegeneration, package.Options, generationItem.NamespaceTransform).ConfigureAwait(true);
+                    result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, null, withRegeneration, options, generationItem.NamespaceTransform).ConfigureAwait(true);
                 }
             }
             else
             {
-                result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, null, withRegeneration, package.Options, generationItem.NamespaceTransform).ConfigureAwait(true);
+                result = await CoreGenerator.Generate(semanticModel, generationItem.SourceSymbol, null, withRegeneration, options, generationItem.NamespaceTransform).ConfigureAwait(true);
             }
 
             return result;

--- a/src/SentryOne.UnitTestGenerator/Helper/CodeGenerator.cs
+++ b/src/SentryOne.UnitTestGenerator/Helper/CodeGenerator.cs
@@ -115,7 +115,7 @@
                 }
                 else
                 {
-                    var textSelection = (TextSelection) targetItem.Document.Selection;
+                    var textSelection = (TextSelection)targetItem.Document.Selection;
                     textSelection.SelectAll();
                     textSelection.Insert(generationItem.TargetContent);
                     targetItem.Document.Save();
@@ -159,7 +159,7 @@
 
         private static async Task GenerateItemAsync(bool withRegeneration, IUnitTestGeneratorOptions options, Solution solution, GenerationItem generationItem)
         {
-            var targetProject = solution.Projects.FirstOrDefault(x => string.Equals(x.Name, generationItem.Source.Project.Name, StringComparison.Ordinal));
+            var targetProject = solution.Projects.FirstOrDefault(x => string.Equals(x.Name, generationItem.Source.SourceProjectName, StringComparison.Ordinal));
             var documents = solution.GetDocumentIdsWithFilePath(generationItem.Source.FilePath);
             var documentId = documents.FirstOrDefault(x => x.ProjectId == targetProject?.Id) ?? documents.FirstOrDefault();
             if (documentId == null)

--- a/src/SentryOne.UnitTestGenerator/Helper/ProjectItemModel.cs
+++ b/src/SentryOne.UnitTestGenerator/Helper/ProjectItemModel.cs
@@ -25,6 +25,7 @@
             Item = projectItem ?? throw new ArgumentNullException(nameof(projectItem));
             FilePath = projectItem.FileNames[1];
             TargetProjectName = options.GetTargetProjectName(Item.ContainingProject.Name);
+            SourceProjectName = Item.ContainingProject.Name;
             try
             {
                 TargetProjectName = string.Format(CultureInfo.CurrentCulture, options.TestProjectNaming, Item.ContainingProject.Name);
@@ -57,6 +58,8 @@
                 return _targetProject ?? (_targetProject = VsProjectHelper.FindProject(Item.DTE.Solution, TargetProjectName));
             }
         }
+
+        public string SourceProjectName { get; }
 
         public string TargetProjectName { get; }
 

--- a/src/SentryOne.UnitTestGenerator/SentryOne.UnitTestGenerator.csproj
+++ b/src/SentryOne.UnitTestGenerator/SentryOne.UnitTestGenerator.csproj
@@ -122,6 +122,9 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="EditorConfig.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=fe6ce3ea283749f2, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\editorconfig.0.12.2\lib\net45\EditorConfig.Core.dll</HintPath>
+    </Reference>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>

--- a/src/SentryOne.UnitTestGenerator/UnitTestGeneratorPackage.cs
+++ b/src/SentryOne.UnitTestGenerator/UnitTestGeneratorPackage.cs
@@ -1,12 +1,9 @@
 ﻿namespace SentryOne.UnitTestGenerator
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using System.Threading;
-    using EditorConfig.Core;
     using Microsoft.VisualStudio.ComponentModelHost;
     using Microsoft.VisualStudio.LanguageServices;
     using Microsoft.VisualStudio.Shell;
@@ -30,25 +27,11 @@
         {
             get
             {
-                var generationOptions = new MutableGenerationOptions((GenerationOptions) GetDialogPage(typeof(GenerationOptions)));
-                var versioningOptions = new MutableVersioningOptions((VersioningOptions) GetDialogPage(typeof(VersioningOptions)));
+                var generationOptions = (GenerationOptions)GetDialogPage(typeof(GenerationOptions));
+                var versioningOptions = (VersioningOptions)GetDialogPage(typeof(VersioningOptions));
 
-                var solution = Workspace.CurrentSolution;
-                if (solution != null)
-                {
-                    var allFiles = new EditorConfigParser(".unitTestGeneratorConfig").GetConfigurationFilesTillRoot(solution.FilePath);
-                    var allProperties = allFiles.SelectMany(x => x.Sections).SelectMany(x => x);
-                    var properties = new Dictionary<string, string>();
-                    foreach (var pair in allProperties)
-                    {
-                        properties[pair.Key] = pair.Value;
-                    }
-
-                    properties.ApplyTo(generationOptions);
-                    properties.ApplyTo(versioningOptions);
-                }
-
-                return new UnitTestGeneratorOptions(generationOptions, versioningOptions);
+                var solutionFilePath = Workspace?.CurrentSolution?.FilePath;
+                return UnitTestGeneratorOptionsFactory.Create(solutionFilePath, generationOptions, versioningOptions);
             }
         }
 

--- a/src/SentryOne.UnitTestGenerator/packages.config
+++ b/src/SentryOne.UnitTestGenerator/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="editorconfig" version="0.12.2" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis" version="2.10.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.9.4" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="2.9.4" targetFramework="net461" developmentDependency="true" />

--- a/src/SentryOne.UnitTestGenerator/source.extension.vsixmanifest
+++ b/src/SentryOne.UnitTestGenerator/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SentryOne.UnitTestGenerator.4a7063ed-7b9a-4195-a740-9976b84638ea" Version="1.0.32" Language="en-US" Publisher="SentryOne" />
+        <Identity Id="SentryOne.UnitTestGenerator.4a7063ed-7b9a-4195-a740-9976b84638ea" Version="1.0.33" Language="en-US" Publisher="SentryOne" />
         <DisplayName>SentryOne Unit Test Generator</DisplayName>
         <Description xml:space="preserve">SentryOne Unit Test Generator generates boiler plate unit test code for existing classes.</Description>
         <Icon>Resources\UnitTestGeneratorPackage.png</Icon>


### PR DESCRIPTION
This fixes #32, #33 and #34 

Detail has been added to the README.MD that includes some description of how the generation process is controlled by using `.unitTestGeneratorConfig` files. Additional tests and coverage have been added.

Also includes some minor formatting updates in unrelated functions.