### PR TITLE
Fixing issues with MSTest & xUnit, and an issue with async mapping methods

### DIFF
--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
@@ -91,8 +91,8 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Frameworks.Test
 
         [TestCase(TestFrameworkTypes.NUnit2, "Assert.ThrowsAsync<int>(() => 1);")]
         [TestCase(TestFrameworkTypes.NUnit3, "Assert.ThrowsAsync<int>(() => 1);")]
-        [TestCase(TestFrameworkTypes.MsTest, "Assert.ThrowsExceptionAsync<int>(() => 1);")]
-        [TestCase(TestFrameworkTypes.XUnit, "Assert.ThrowsAsync<int>(() => 1);")]
+        [TestCase(TestFrameworkTypes.MsTest, "await Assert.ThrowsExceptionAsync<int>(() => 1);")]
+        [TestCase(TestFrameworkTypes.XUnit, "await Assert.ThrowsAsync<int>(() => 1);")]
         public void CanCallAssertThrowsAsync(TestFrameworkTypes frameworkTypes, string expectedOutput)
         {
             var testClass = CreateFramework(frameworkTypes);
@@ -132,7 +132,7 @@ namespace SentryOne.UnitTestGenerator.Core.Tests.Frameworks.Test
 
         [TestCase(TestFrameworkTypes.NUnit2, "[Test]\r\npublic static void TestValue1606901338()")]
         [TestCase(TestFrameworkTypes.NUnit3, "[Test]\r\npublic static void TestValue1606901338()")]
-        [TestCase(TestFrameworkTypes.MsTest, "[TestMethod]\r\npublic static void TestValue1606901338()")]
+        [TestCase(TestFrameworkTypes.MsTest, "[TestMethod]\r\npublic void TestValue1606901338()")]
         [TestCase(TestFrameworkTypes.XUnit, "[Fact]\r\npublic static void TestValue1606901338()")]
         public void CanCallCreateTestMethod(TestFrameworkTypes frameworkTypes, string expectedOutput)
         {

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/AsyncMappingMethod.txt
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/Resources/AsyncMappingMethod.txt
@@ -1,0 +1,31 @@
+namespace TestApp1
+{
+    using System.Threading.Tasks;
+
+    public class InputClass
+    {
+        public int ID { get; }
+        public string SomeProperty { get; }
+        public string SomeOtherProperty { get; set; }
+        public string WriteOnlyProperty { set { } }
+    }
+
+    public class OutputClass
+    {
+        public string SomeProperty { get; set; }
+        public string SomeOtherProperty { get; set; }
+        public string WriteOnlyProperty { get; set; }
+    }
+    public class C3
+    {
+        public async Task ShouldntMap(InputClass inputClass)
+        {
+            return;
+        }
+
+        public async Task<OutputClass> MapActually(InputClass inputClass)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/SentryOne.UnitTestGenerator.Core.Tests.csproj
@@ -482,6 +482,9 @@
   <ItemGroup>
     <None Include="Resources\AbstractSelfReferencingClass.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AsyncMappingMethod.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.Designer.cs
@@ -180,7 +180,31 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to using System;
+        ///using System.Collections.Generic;
+        ///using System.Linq;
+        ///using System.Text;
+        ///using System.Threading.Tasks;
+        ///
+        ///namespace BasicProject
+        ///{
+        ///    public abstract class AbsTest
+        ///    {
+        ///        protected static string GetString()
+        ///        {
+        ///            return &quot;string&quot;;
+        ///        }
+        ///
+        ///        public AbsTest(IEnumerable&lt;AbsTest&gt; childSelectors)
+        ///        {
+        ///        }
+        ///    }
+        ///
+        ///    public class AbsTestThing : AbsTest
+        ///    {
+        ///        public AbsTestThing() : base(Enumerable.Empty&lt;AbsTest&gt;())
+        ///        {
+        ///    [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AbstractSelfReferencingClass {
             get {
@@ -204,6 +228,15 @@ namespace SentryOne.UnitTestGenerator.Core.Tests {
         internal static string ArrowPropertyGetter {
             get {
                 return ResourceManager.GetString("ArrowPropertyGetter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string AsyncMappingMethod {
+            get {
+                return ResourceManager.GetString("AsyncMappingMethod", resourceCulture);
             }
         }
         

--- a/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
+++ b/src/SentryOne.UnitTestGenerator.Core.Tests/TestClasses.resx
@@ -136,6 +136,9 @@
   <data name="ArrowPropertyGetter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ArrowPropertyGetter.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="AsyncMappingMethod" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\AsyncMappingMethod.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="AsyncMethod" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\AsyncMethod.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/SentryOne.UnitTestGenerator.Core/Frameworks/ITestFramework.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Frameworks/ITestFramework.cs
@@ -7,6 +7,10 @@
 
     public interface ITestFramework
     {
+        bool SupportsStaticTestClasses { get; }
+
+        bool AssertThrowsAsyncIsAwaitable { get; }
+
         AttributeSyntax SingleThreadedApartmentAttribute { get; }
 
         string TestClassAttribute { get; }

--- a/src/SentryOne.UnitTestGenerator.Core/Frameworks/Test/NUnitTestFramework.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Frameworks/Test/NUnitTestFramework.cs
@@ -11,6 +11,10 @@
 
     public abstract class NUnitTestFramework : ITestFramework
     {
+        public bool SupportsStaticTestClasses => true;
+
+        public bool AssertThrowsAsyncIsAwaitable => false;
+
         public abstract AttributeSyntax SingleThreadedApartmentAttribute { get; }
 
         public string TestClassAttribute => "TestFixture";

--- a/src/SentryOne.UnitTestGenerator.Core/Frameworks/Test/XUnitTestFramework.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Frameworks/Test/XUnitTestFramework.cs
@@ -11,6 +11,10 @@
 
     public class XUnitTestFramework : ITestFramework
     {
+        public bool SupportsStaticTestClasses => true;
+
+        public bool AssertThrowsAsyncIsAwaitable => true;
+
         public AttributeSyntax SingleThreadedApartmentAttribute => null;
 
         public string TestClassAttribute => string.Empty;
@@ -113,12 +117,12 @@
 
         public StatementSyntax AssertThrows(TypeSyntax exceptionType, ExpressionSyntax methodCall)
         {
-            return AssertThrows(exceptionType, methodCall, "Throws");
+            return SyntaxFactory.ExpressionStatement(AssertThrows(exceptionType, methodCall, "Throws"));
         }
 
         public StatementSyntax AssertThrowsAsync(TypeSyntax exceptionType, ExpressionSyntax methodCall)
         {
-            return AssertThrows(exceptionType, methodCall, "ThrowsAsync");
+            return SyntaxFactory.ExpressionStatement(SyntaxFactory.AwaitExpression(AssertThrows(exceptionType, methodCall, "ThrowsAsync")));
         }
 
         public BaseMethodDeclarationSyntax CreateSetupMethod(string targetTypeName)
@@ -196,7 +200,7 @@
                 SyntaxFactory.IdentifierName(assertMethod)));
         }
 
-        private static StatementSyntax AssertThrows(TypeSyntax exceptionType, ExpressionSyntax methodCall, string throws)
+        private static InvocationExpressionSyntax AssertThrows(TypeSyntax exceptionType, ExpressionSyntax methodCall, string throws)
         {
             if (exceptionType == null)
             {
@@ -208,13 +212,13 @@
                 throw new ArgumentNullException(nameof(methodCall));
             }
 
-            return SyntaxFactory.ExpressionStatement(SyntaxFactory.InvocationExpression(
+            return SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("Assert"),
                         SyntaxFactory.GenericName(SyntaxFactory.Identifier(throws))
                             .WithTypeArgumentList(SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(exceptionType)))))
-                .WithArgumentList(Generate.Arguments(Generate.ParenthesizedLambdaExpression(methodCall))));
+                .WithArgumentList(Generate.Arguments(Generate.ParenthesizedLambdaExpression(methodCall)));
         }
     }
 }

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/ClassGeneration/StaticClassGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/ClassGeneration/StaticClassGenerationStrategy.cs
@@ -40,7 +40,12 @@
 
             model.TargetInstance = model.TypeSyntax;
 
-            classDeclaration = classDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+            classDeclaration = classDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+            if (_frameworkSet.TestFramework.SupportsStaticTestClasses)
+            {
+                classDeclaration = classDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+            }
+
             if (!string.IsNullOrWhiteSpace(_frameworkSet.TestFramework.TestClassAttribute))
             {
                 var testFixtureAtt = Generate.Attribute(_frameworkSet.TestFramework.TestClassAttribute);

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
@@ -72,7 +72,7 @@
                 var paramList = new List<CSharpSyntaxNode>();
 
                 var methodName = string.Format(CultureInfo.InvariantCulture, "CannotCall{0}WithNull{1}", model.GetMethodUniqueName(method), method.Parameters[i].Name.ToPascalCase());
-                var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(methodName, false, model.IsStatic);
+                var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(methodName, method.IsAsync && _frameworkSet.TestFramework.AssertThrowsAsyncIsAwaitable, model.IsStatic);
 
                 for (var index = 0; index < method.Parameters.Count; index++)
                 {

--- a/src/SentryOne.UnitTestGenerator.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
+++ b/src/SentryOne.UnitTestGenerator.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
@@ -67,7 +67,7 @@
                 var paramList = new List<CSharpSyntaxNode>();
 
                 var methodName = string.Format(CultureInfo.InvariantCulture, "CannotCall{0}WithInvalid{1}", model.GetMethodUniqueName(method), method.Parameters[i].Name.ToPascalCase());
-                var generatedMethod = _frameworkSet.TestFramework.CreateTestCaseMethod(methodName, false, model.IsStatic, SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)), new object[] { null, string.Empty, "   " });
+                var generatedMethod = _frameworkSet.TestFramework.CreateTestCaseMethod(methodName, method.IsAsync && _frameworkSet.TestFramework.AssertThrowsAsyncIsAwaitable, model.IsStatic, SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)), new object[] { null, string.Empty, "   " });
 
                 for (var index = 0; index < method.Parameters.Count; index++)
                 {

--- a/src/SentryOne.UnitTestGenerator/source.extension.vsixmanifest
+++ b/src/SentryOne.UnitTestGenerator/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SentryOne.UnitTestGenerator.4a7063ed-7b9a-4195-a740-9976b84638ea" Version="1.0.33" Language="en-US" Publisher="SentryOne" />
+        <Identity Id="SentryOne.UnitTestGenerator.4a7063ed-7b9a-4195-a740-9976b84638ea" Version="1.0.34" Language="en-US" Publisher="SentryOne" />
         <DisplayName>SentryOne Unit Test Generator</DisplayName>
         <Description xml:space="preserve">SentryOne Unit Test Generator generates boiler plate unit test code for existing classes.</Description>
         <Icon>Resources\UnitTestGeneratorPackage.png</Icon>


### PR DESCRIPTION
This fixes the fact that Assert.ThrowsAsync is awaitable in MSTest and xUnit, fixes the fact that MSTest balks on static test classes and fixes an oddity with Mapping method generation on async Task methods.

Fixes #37, #39 